### PR TITLE
Clean up AppEngine::Env, and update stackdriver dependency

### DIFF
--- a/appengine.gemspec
+++ b/appengine.gemspec
@@ -39,7 +39,8 @@ require 'appengine/version'
   spec.required_ruby_version = ">= 2.0.0"
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "stackdriver", "~> 0.4", ">= 0.4.1"
+  spec.add_dependency "google-cloud-env", "~> 1.0"
+  spec.add_dependency "stackdriver", "~> 0.6"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/lib/appengine/env.rb
+++ b/lib/appengine/env.rb
@@ -13,18 +13,26 @@
 # limitations under the License.
 ;
 
+require "google/cloud/env"
+
 
 module AppEngine
 
   ##
-  # A collection of functions for extracting App Engine environment information.
+  # A convenience object that provides information on the Google Cloud
+  # hosting environment. For example, you can call
   #
-  module Env
-
-    def self.app_engine?
-      ::ENV["GAE_INSTANCE"] ? true : false
-    end
-
-  end
+  #     if AppEngine::Env.app_engine?
+  #       # Do something
+  #     end
+  #
+  # Technically, `Env` is not actually a module, but is simply set to the
+  # `Google::Cloud.env` object.
+  #
+  # This is provided mostly for backward compatibility with previous usage, and
+  # is mildly deprecated. Generally, you should call `Google::Cloud.env`
+  # directly instead. See the documentation for the `google-cloud-env` gem.
+  #
+  Env = ::Google::Cloud.env
 
 end

--- a/test/test_env.rb
+++ b/test/test_env.rb
@@ -22,14 +22,12 @@ module AppEngine
 
     class TestEnv < ::Minitest::Test  # :nodoc:
 
-
       def test_app_engine
         ::ENV["GAE_INSTANCE"] = "instance-123"
         assert Env.app_engine?
         ::ENV.delete "GAE_INSTANCE"
         refute Env.app_engine?
       end
-
 
     end
 


### PR DESCRIPTION
Changes:

* Update `stackdriver` dependency to require at least version 0.6.
* Change `AppEngine::Env` to alias `Google::Cloud.env`.
