### PR TITLE
Use Shellwords.split instead of Shellwords.parse when running Exec

### DIFF
--- a/lib/appengine/exec.rb
+++ b/lib/appengine/exec.rb
@@ -502,7 +502,7 @@ module AppEngine
     #
     def resolve_parameters
       @timestamp_suffix = ::Time.now.strftime "%Y%m%d%H%M%S"
-      @command = ::Shellwords.parse @command.to_s unless @command.is_a? Array
+      @command = ::Shellwords.split @command.to_s unless @command.is_a? Array
       @project ||= default_project
       @service ||= service_from_config || Exec.default_service
       @version ||= latest_version @service


### PR DESCRIPTION
`Shellwords.parse` does not exist