### PR TITLE
Add CLOUD_BUILD_GCS_LOG_DIR option to read cloud build logs

### DIFF
--- a/lib/appengine/exec.rb
+++ b/lib/appengine/exec.rb
@@ -175,6 +175,11 @@ module AppEngine
   # accessed only over a private IP, you should use the `deployment` strategy
   # instead.
   #
+  # The Cloud Build log is output to the directory specified by
+  # "CLOUD_BUILD_GCS_LOG_DIR". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
+  # By default, log directory name is
+  # "gs://[PROJECT_NUMBER].cloudbuild-logs.googleusercontent.com/".
+  #
   # ### Specifying the host application
   #
   # The `cloud_build` strategy needs to know exactly which app, service, and
@@ -365,11 +370,13 @@ module AppEngine
       #     standard). Allowed values are `nil`, `"deployment"` (which is the
       #     default for Standard), and `"cloud_build"` (which is the default
       #     for Flexible).
+      # @param gcs_log_dir [String,nil] GCS bucket name of the cloud build log
+      #     when strategy is "cloud_build". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
       #
       def new_rake_task name, args: [], env_args: [],
                         service: nil, config_path: nil, version: nil,
                         timeout: nil, project: nil, wrapper_image: nil,
-                        strategy: nil
+                        strategy: nil, gcs_log_dir: nil
         escaped_args = args.map do |arg|
           arg.gsub(/[,\[\]]/) { |m| "\\#{m}" }
         end
@@ -382,7 +389,7 @@ module AppEngine
         new ["bundle", "exec", "rake", name_with_args] + env_args,
             service: service, config_path: config_path, version: version,
             timeout: timeout, project: project, wrapper_image: wrapper_image,
-            strategy: strategy
+            strategy: strategy, gcs_log_dir: gcs_log_dir
       end
     end
 
@@ -410,10 +417,12 @@ module AppEngine
     #     standard). Allowed values are `nil`, `"deployment"` (which is the
     #     default for Standard), and `"cloud_build"` (which is the default for
     #     Flexible).
+    # @param gcs_log_dir [String,nil] GCS bucket name of the cloud build log
+    #     when strategy is "cloud_build". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
     #
     def initialize command,
                    project: nil, service: nil, config_path: nil, version: nil,
-                   timeout: nil, wrapper_image: nil, strategy: nil
+                   timeout: nil, wrapper_image: nil, strategy: nil, gcs_log_dir: nil
       @command = command
       @service = service
       @config_path = config_path
@@ -422,6 +431,7 @@ module AppEngine
       @project = project
       @wrapper_image = wrapper_image
       @strategy = strategy
+      @gcs_log_dir = gcs_log_dir
 
       yield self if block_given?
     end
@@ -760,13 +770,17 @@ module AppEngine
       begin
         ::JSON.dump config, file
         file.flush
-        Util::Gcloud.execute [
+        execute_command = [
           "builds", "submit",
           "--project", @project,
           "--no-source",
           "--config", file.path,
-          "--timeout", @timeout
+          "--timeout", @timeout,
         ]
+        execute_command.concat([
+          "--gcs-log-dir", @gcs_log_dir
+        ]) unless @gcs_log_dir.nil?
+        Util::Gcloud.execute execute_command
       ensure
         file.close!
       end

--- a/lib/appengine/tasks.rb
+++ b/lib/appengine/tasks.rb
@@ -113,6 +113,10 @@ module AppEngine
   # the "cloud_build" strategy, and applies only to that strategy.) Normally,
   # you should not override this unless you are testing a new wrapper.
   #
+  # #### CLOUD_BUILD_GCS_LOG_DIR
+  #
+  # GCS bucket name of the cloud build log when GAE_STRATEGY is "cloud_build".
+  # (ex. "gs://BUCKET-NAME/FOLDER-NAME")
   module Tasks
     ## @private
     PROJECT_ENV = "GAE_PROJECT"
@@ -128,6 +132,8 @@ module AppEngine
     TIMEOUT_ENV = "GAE_TIMEOUT"
     ## @private
     WRAPPER_IMAGE_ENV = "GAE_EXEC_WRAPPER_IMAGE"
+    ## @private
+    GCS_LOG_DIR = "CLOUD_BUILD_GCS_LOG_DIR"
 
     @defined = false
 
@@ -161,7 +167,8 @@ module AppEngine
                               version:       ::ENV[VERSION_ENV],
                               timeout:       ::ENV[TIMEOUT_ENV],
                               wrapper_image: ::ENV[WRAPPER_IMAGE_ENV],
-                              strategy:      ::ENV[STRATEGY_ENV]
+                              strategy:      ::ENV[STRATEGY_ENV],
+                              gcs_log_dir:   ::ENV[GCS_LOG_DIR]
           start_and_report_errors app_exec
           exit
         end
@@ -273,6 +280,11 @@ module AppEngine
             image that emulates the App Engine environment in Google Cloud Build for
             the "cloud_build" strategy, and applies only to that strategy.) Normally,
             you should not override this unless you are testing a new wrapper.
+
+          CLOUD_BUILD_GCS_LOG_DIR
+
+            GCS bucket name of the cloud build log when GAE_STRATEGY is "cloud_build".
+            (ex. "gs://BUCKET-NAME/FOLDER-NAME")
 
           This rake task is provided by the "appengine" gem. To make these tasks
           available, add the following line to your Rakefile:


### PR DESCRIPTION
It faild reading the cloud build logs When GAE_EXEC_STRATEGY is cloud_build.

```
ERROR: (gcloud.container.builds.submit) HTTPError 403: <?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>circleci@project.iam.gserviceaccount.com does not have storage.objects.get access to PROJECT_ID.cloudbuild-logs.googleusercontent.com/log-xxxxxxxxxxxxxxx.txt.</Details></Error>
```

I found the following Github issue.

https://github.com/GoogleCloudPlatform/cloud-builders/issues/120

So, I add `CLOUD_BUILD_GCS_LOG_DIR` option to add `--gcs-log-dir` option for gcloud command.

## Usage

```
bundle exec rake CLOUD_BUILD_GCS_LOG_DIR="gs://appengine-katsuyan-test/cloudbuild" appengine:exec -- bundle exec rails db:migrate
```